### PR TITLE
fix route order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -385,6 +385,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -959,6 +960,7 @@
       "integrity": "sha512-20MV9SUdeN6Jd84xESsKhRly+/vxI+hwvpBMA93s+9dAcjdCuCojn4IqUGS3lvVaqjVYGYHSRMCpeFtF2rQYxQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",

--- a/src/routes/storyRoutes.js
+++ b/src/routes/storyRoutes.js
@@ -2,14 +2,14 @@ import { Router } from "express";
 import { celebrate } from "celebrate";
 import { authenticate } from "../middleware/authenticate.js";
 import {
-    getMyStories,
-    getAllStories,
-    getStoryById,
-    getSavedStories,
-    addToSave,
-    removeFromSave,
-    createStory,
-    updateStory
+  getMyStories,
+  getAllStories,
+  getStoryById,
+  getSavedStories,
+  addToSave,
+  removeFromSave,
+  createStory,
+  updateStory,
 } from "../controllers/storyController.js";
 import * as schemas from "../validations/storyValidation.js";
 import { upload } from "../middleware/multer.js";
@@ -19,23 +19,49 @@ const router = Router();
 // 1. ПУБЛІЧНИЙ: Отримання всіх історій (пагінація + фільтр)
 router.get("/stories", celebrate(schemas.getAllStoriesSchema), getAllStories);
 
-// 2. ПУБЛІЧНИЙ: Отримання однієї історії за ID
-router.get('/stories/:storyId', celebrate(schemas.getStoryByIdSchema), getStoryById);
-
 // 3. ПРИВАТНИЙ: Отримання власних історій (OwnStories)
-router.get("/stories/own", authenticate, celebrate(schemas.getMyStoriesSchema), getMyStories);
+router.get(
+  "/stories/own",
+  authenticate,
+  celebrate(schemas.getMyStoriesSchema),
+  getMyStories,
+);
 
 // 4. ПРИВАТНИЙ: Отримання збережених історій (SavedStories)
-router.get('/stories/saved', authenticate, celebrate(schemas.getSavedStoriesSchema), getSavedStories);
+router.get(
+  "/stories/saved",
+  authenticate,
+  celebrate(schemas.getSavedStoriesSchema),
+  getSavedStories,
+);
+
+// 2. ПУБЛІЧНИЙ: Отримання однієї історії за ID
+router.get(
+  "/stories/:storyId",
+  celebrate(schemas.getStoryByIdSchema),
+  getStoryById,
+);
 
 // 5. ПРИВАТНИЙ: Створення історії (Приватний + завантаження фото + валідація body)
-router.post('/stories', authenticate, upload.single('img'), celebrate(schemas.createStorySchema), createStory);
+router.post(
+  "/stories",
+  authenticate,
+  upload.single("img"),
+  celebrate(schemas.createStorySchema),
+  createStory,
+);
 
 // 6. ПРИВАТНИЙ: Редагування історії (Приватний + завантаження фото + валідація params/body)
-router.patch('/stories/:storyId', authenticate, upload.single('img'), celebrate(schemas.updateStorySchema), updateStory);
+router.patch(
+  "/stories/:storyId",
+  authenticate,
+  upload.single("img"),
+  celebrate(schemas.updateStorySchema),
+  updateStory,
+);
 
 // 7. ПРИВАТНИЙ: Додавання/Видалення зі збережених
-router.post('/stories/:storyId/save', authenticate, addToSave);
-router.delete('/stories/:storyId/save', authenticate, removeFromSave);
+router.post("/stories/:storyId/save", authenticate, addToSave);
+router.delete("/stories/:storyId/save", authenticate, removeFromSave);
 
 export default router;


### PR DESCRIPTION
Якшо зараз залишимо порядок як є - то ламаються приватні маршрути, оскількі спочатку йде валідація як не по порядку, і тоді приватні марштути спершу фейляться через інші правила валідації минуючи авторизацію.

ось що я маю на увазі:
<img width="993" height="850" alt="Screenshot From 2026-02-21 14-38-40" src="https://github.com/user-attachments/assets/fcaff05a-62aa-4cb7-bab3-9ad77306a762" />

пропоную такий порядок роутів:
1,3,4,2,5,6,7
бо 
конкретні маршрути (зі статичною частиною) повинні бути перед динамічними (з параметрами :id)

в такому випадку одразу йде перевірка на авторизацію

<img width="993" height="850" alt="Screenshot From 2026-02-21 14-41-37" src="https://github.com/user-attachments/assets/42272e15-9030-4f2e-8ab1-095fe41a0186" />
<img width="993" height="850" alt="Screenshot From 2026-02-21 14-42-34" src="https://github.com/user-attachments/assets/f6f3ce24-8bf2-4788-8a33-8ce2b59d033c" />